### PR TITLE
fix keybinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,24 @@
 
 Fractouille is a simple fractal explorer running in your terminal.
 
-You can find all the keybinds in the title bar!
-
 It is better to use cargo build --release to build it, as it is a bit slow otherwise.
 
-TODO:
+## Keybinds
+
+- `wasd`: Move around
+- `q`: quit fractouille
+- `r/f`: increase/decrease max iterations
+- `-/`: decrease/increase zoom level
+- `space`: change color palette
+- `enter`: change set
+- `:`: enter command mode
+- `esc`: exit command mode
+
+## Command mode
+
+Pressing `:` enters command mode. A list of all available commands can be found by in the `COMMANDS.md` file.
+
+## TODO:
 - [x] Mandelbrot
 - [x] Julia
 - [x] Burning Ship
@@ -16,7 +29,7 @@ TODO:
 - [x] Smooth coloring on screenshots
 - [ ] Have deep zoom
 - [ ] Saving location
-- [ ] Auto move / zoom to saved locations
+- [x] Auto move / zoom to saved locations
 - [ ] Make more and better looking color palettes
 - [x] Being able to change the power, not only quadratic
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,7 @@ impl App {
 impl Widget for &mut App {
   fn render(self, area: Rect, buf: &mut Buffer) {
     let layout = if self.show_extended_menu {
-      Layout::vertical([Length(4), Min(0), Length(1)])
+      Layout::vertical([Length(5), Min(0), Length(1)])
     } else {
       Layout::vertical([Length(1), Min(0), Length(1)])
     };
@@ -154,6 +154,7 @@ impl Widget for &mut App {
         } else {
           "".to_string()
         },
+        "wasd to move | r/f to change max iteration | -/+ to zoom | q to quit".to_string(),
         if self.command_mode {
           "Command Mode: ACTIVE (ESC to exit) | Type 'commands' for command list"
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,7 @@ impl App {
               self.command_mode = true;
               self.command_string.clear();
             }
+            KeyCode::Char('q') => self.quit_requested = true,
             KeyCode::Char('+') | KeyCode::Char('=') => f.scale *= 1.1,
             KeyCode::Char('-') => f.scale /= 1.1,
             KeyCode::Char('r') => f.max_iterations += 1,


### PR DESCRIPTION
Resolve #6

- bring back the `q` keybind
- add a section for keybinds and commands in the `README.md` file.
- add a line in the extended menu showing keybinds.